### PR TITLE
Change model output to dictionary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,9 @@ ARG DEEPCELL_VERSION=0.11.0-gpu
 
 FROM vanvalenlab/deepcell-tf:${DEEPCELL_VERSION}
 
+# https://forums.developer.nvidia.com/t/notice-cuda-linux-repository-key-rotation/212771
+RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub
+
 # Install git for postcode installation
 RUN apt-get update && apt-get install -y \
     git && \

--- a/deepcell_spots/applications/spot_detection.py
+++ b/deepcell_spots/applications/spot_detection.py
@@ -41,9 +41,11 @@ from deepcell_spots.preprocessing_utils import min_max_normalize
 MODEL_PATH = ('https://deepcell-data.s3-us-west-1.amazonaws.com/'
               'saved-models/SpotDetection-3.tar.gz')
 
+
 def output_to_dictionary(output_images, output_names):
     return {name: pred for name, pred in zip(output_names,
                                              output_images)}
+
 
 class SpotDetection(Application):
     """Loads a :mod:`deepcell.model_zoo.featurenet.FeatureNet` model

--- a/deepcell_spots/applications/spot_detection.py
+++ b/deepcell_spots/applications/spot_detection.py
@@ -140,7 +140,8 @@ class SpotDetection(Application):
         output_images = self._untile_output(output_tiles, tiles_info)
 
         # restructure outputs into a dict if function provided
-        formatted_images = {name: pred for name, pred in zip(self.model.output_names, output_images)}
+        formatted_images = {name: pred for name, pred in zip(self.model.output_names,
+                                                             output_images)}
 
         return formatted_images
 

--- a/deepcell_spots/applications/spot_detection.py
+++ b/deepcell_spots/applications/spot_detection.py
@@ -190,8 +190,10 @@ class SpotDetection(Application):
         # Resize output_images back to original resolution if necessary
         label_image = self._resize_output(output_images, image.shape)
 
+        label_image_dict = {name: pred for name, pred in zip(self.model.output_names, label_image)}
+
         # Postprocess predictions to create label image
-        predicted_spots = self._postprocess(label_image, **postprocess_kwargs)
+        predicted_spots = self._postprocess(label_image_dict, **postprocess_kwargs)
 
         return predicted_spots
 

--- a/deepcell_spots/dotnet.py
+++ b/deepcell_spots/dotnet.py
@@ -50,7 +50,7 @@ def default_heads(input_shape, num_classes):
         list(tuple): A list of tuple, where the first element is the name of
             the submodel and the second element is the submodel itself.
     """
-    # regress x and y coordinates (pixel center signed distance from  nearest object center)
+    # regress x and y coordinates (pixel center signed distance from nearest object center)
     num_dimensions = 2
     return [
         ('offset_regression', offset_regression_head(
@@ -91,9 +91,7 @@ def classification_head(input_shape,
     x.append(Activation('relu')(x[-1]))
     x.append(TensorProduct(n_features, kernel_initializer=init,
                            kernel_regularizer=l2(reg))(x[-1]))
-    # x.append(Flatten()(x[-1]))
     outputs = Softmax(axis=channel_axis)(x[-1])
-    # x.append(outputs)
 
     return Model(inputs=inputs, outputs=outputs, name=name)
 
@@ -125,8 +123,6 @@ def offset_regression_head(num_values,
 
     return Model(inputs=inputs, outputs=outputs, name=name)
 
-# TO BE DELETED - only needed when there are multiple features but here have only 1 backbone_output
-
 
 def __build_model_heads(name, model, backbone_output):
     identity = Lambda(lambda x: x, name=name)
@@ -146,9 +142,6 @@ def dot_net_2D(receptive_field=13,
 
     inputs = Input(shape=input_shape)
 
-    # models  = []
-    # model_outputs = [] # AAA outputs all the intermediate outputs used for skips in featurenet
-
     featurenet_model = bn_feature_net_skip_2D(
         receptive_field=receptive_field,
         input_shape=inputs.get_shape().as_list()[1:],
@@ -165,9 +158,6 @@ def dot_net_2D(receptive_field=13,
 
     featurenet_output = featurenet_model(inputs)
 
-    # model_outputs.append(featurenet_output)
-    # models.append(featurenet_model)
-
     # add 2 heads: 1 for center pixel classification
     # (should be 1 for pixel which has center, 0 otherwise),
     # and 1 for center location regression
@@ -183,6 +173,5 @@ def dot_net_2D(receptive_field=13,
                 for n, m in head_submodels]
     outputs = dot_head
 
-    # model = Model(inputs=inputs, outputs=outputs, name=name)
     model = Model(inputs=inputs, outputs=outputs)
     return model

--- a/deepcell_spots/dotnet.py
+++ b/deepcell_spots/dotnet.py
@@ -50,11 +50,9 @@ def default_heads(input_shape, num_classes):
         list(tuple): A list of tuple, where the first element is the name of
             the submodel and the second element is the submodel itself.
     """
-    # regress x and y coordinates (pixel center signed distance from nearest object center)
-    num_dimensions = 2
     return [
         ('offset_regression', offset_regression_head(
-            num_values=num_dimensions, input_shape=input_shape)),
+            input_shape=input_shape)),
         ('classification', classification_head(
             input_shape, n_features=num_classes))
     ]
@@ -96,8 +94,7 @@ def classification_head(input_shape,
     return Model(inputs=inputs, outputs=outputs, name=name)
 
 
-def offset_regression_head(num_values,
-                           input_shape,
+def offset_regression_head(input_shape,
                            regression_feature_size=256,
                            name='offset_regression_head'):
 
@@ -127,9 +124,6 @@ def offset_regression_head(num_values,
 def __build_model_heads(name, model, backbone_output):
     identity = Lambda(lambda x: x, name=name)
     return identity(model(backbone_output))
-    # for name, model in head_submodels: # DELETE?
-    # concat = Concatenate(axis=1, name=name)
-    # return concat([model(backbone_output)])
 
 
 def dot_net_2D(receptive_field=13,
@@ -171,7 +165,6 @@ def dot_net_2D(receptive_field=13,
     head_submodels = default_heads(input_shape=input_shape, num_classes=2)
     dot_head = [__build_model_heads(n, m, featurenet_output)
                 for n, m in head_submodels]
-    outputs = dot_head
 
-    model = Model(inputs=inputs, outputs=outputs)
+    model = Model(inputs=inputs, outputs=dot_head)
     return model

--- a/deepcell_spots/postprocessing_utils.py
+++ b/deepcell_spots/postprocessing_utils.py
@@ -49,6 +49,11 @@ def y_annotations_to_point_list(y_pred, threshold=0.95):
     Returns:
         list: spot center coordinates of the format [[y0, x0], [y1, x1],...]
     """
+    if type(y_pred) is not dict:
+        raise TypeError('Input predictions must be a dictionary.')
+    if 'classification' not in y_pred.keys() or 'offset_regression' not in y_pred.keys():
+        raise NameError('Input must have keys \'classification\' and \'offset_regression\'')
+
     dot_centers = []
     for ind in range(np.shape(y_pred['classification'])[0]):
         contains_dot = y_pred['classification'][ind, ..., 1] > threshold
@@ -81,6 +86,11 @@ def y_annotations_to_point_list_restrictive(y_pred, threshold=0.95):
     Returns:
         list: spot center coordinates of the format [[y0, x0], [y1, x1],...]
     """
+    if type(y_pred) is not dict:
+        raise TypeError('Input predictions must be a dictionary.')
+    if 'classification' not in y_pred.keys() or 'offset_regression' not in y_pred.keys():
+        raise NameError('Input must have keys \'classification\' and \'offset_regression\'')
+
     dot_centers = []
     for ind in range(np.shape(y_pred['classification'])[0]):
         contains_dot = y_pred['classification'][ind, ..., 1] > threshold
@@ -115,6 +125,11 @@ def y_annotations_to_point_list_max(y_pred, threshold=0.95, min_distance=2):
     Returns:
         list: spot center coordinates of the format [[y0, x0], [y1, x1],...]
     """
+    if type(y_pred) is not dict:
+        raise TypeError('Input predictions must be a dictionary.')
+    if 'classification' not in y_pred.keys() or 'offset_regression' not in y_pred.keys():
+        raise NameError('Input must have keys \'classification\' and \'offset_regression\'')
+
     dot_centers = []
     for ind in range(np.shape(y_pred['classification'])[0]):
         dot_pixel_inds = peak_local_max(y_pred['classification'][ind, ..., 1],
@@ -134,6 +149,10 @@ def y_annotations_to_point_list_max(y_pred, threshold=0.95, min_distance=2):
 def y_annotations_to_point_list_cc(y_pred, threshold=0.95):
     # make final decision to be: average regression over each connected component of above
     # detection threshold pixels
+    if type(y_pred) is not dict:
+        raise TypeError('Input predictions must be a dictionary.')
+    if 'classification' not in y_pred.keys() or 'offset_regression' not in y_pred.keys():
+        raise NameError('Input must have keys \'classification\' and \'offset_regression\'')
 
     dot_centers = []
     for ind in range(np.shape(y_pred['classification'])[0]):

--- a/deepcell_spots/postprocessing_utils.py
+++ b/deepcell_spots/postprocessing_utils.py
@@ -50,7 +50,7 @@ def y_annotations_to_point_list(y_pred, threshold=0.95):
         list: spot center coordinates of the format [[y0, x0], [y1, x1],...]
     """
     dot_centers = []
-    for ind in range(np.shape(y_pred)['classification']):
+    for ind in range(np.shape(y_pred['classification'])[0]):
         contains_dot = y_pred['classification'][ind, ..., 1] > threshold
         delta_y = y_pred['offset_regression'][ind, ..., 0]
         delta_x = y_pred['offset_regression'][ind, ..., 1]
@@ -82,7 +82,7 @@ def y_annotations_to_point_list_restrictive(y_pred, threshold=0.95):
         list: spot center coordinates of the format [[y0, x0], [y1, x1],...]
     """
     dot_centers = []
-    for ind in range(np.shape(y_pred)['classification']):
+    for ind in range(np.shape(y_pred['classification'])[0]):
         contains_dot = y_pred['classification'][ind, ..., 1] > threshold
         delta_y = y_pred['offset_regression'][ind, ..., 0]
         delta_x = y_pred['offset_regression'][ind, ..., 1]
@@ -116,7 +116,7 @@ def y_annotations_to_point_list_max(y_pred, threshold=0.95, min_distance=2):
         list: spot center coordinates of the format [[y0, x0], [y1, x1],...]
     """
     dot_centers = []
-    for ind in range(np.shape(y_pred)['classification']):
+    for ind in range(np.shape(y_pred['classification'])[0]):
         dot_pixel_inds = peak_local_max(
             y_pred['classification'][ind, ..., 1], min_distance=min_distance, threshold_abs=threshold)
 
@@ -135,7 +135,7 @@ def y_annotations_to_point_list_cc(y_pred, threshold=0.95):
     # detection threshold pixels
 
     dot_centers = []
-    for ind in range(np.shape(y_pred)['classification']):
+    for ind in range(np.shape(y_pred['classification'])[0]):
 
         delta_y = y_pred['offset_regression'][ind, ..., 0]
         delta_x = y_pred['offset_regression'][ind, ..., 1]

--- a/deepcell_spots/postprocessing_utils.py
+++ b/deepcell_spots/postprocessing_utils.py
@@ -31,30 +31,29 @@ from skimage import measure
 from skimage.feature import peak_local_max
 
 
-def y_annotations_to_point_list(y_pred, threshold):
+def y_annotations_to_point_list(y_pred, threshold=0.95):
     """Convert raw prediction to a predicted point list: classification of
-    pixel as containing dot > threshold
+    pixel as containing dot > threshold, , and their corresponding regression
+    values will be used to create a final spot position prediction which will
+    be added to the output spot center coordinates list.
 
     Args:
-        y_pred: a batch of predictions, of the format: y_pred[annot_type][ind]
-            is an annotation for image #ind in the batch where annot_type = 0
-            or 1: 0 - contains_dot, 1 - offset matrices
+        y_pred: a dictionary of predictions with keys 'classification' and
+            'offset_regression' corresponding to the named outputs of the
+            dot_net_2D model
         ind: the index of the image in the batch for which to convert the
             annotations
         threshold: a number in [0, 1]. Pixels with classification
-            score > threshold are considered containing a spot center, and
-            their corresponding regression values will be used to create a
-            final spot position prediction which will be added to the output
-            spot center coordinates list.
+            score > threshold are considered containing a spot center
 
     Returns:
         list: spot center coordinates of the format [[y0, x0], [y1, x1],...]
     """
     dot_centers = []
-    for ind in range(np.shape(y_pred)[1]):
-        contains_dot = y_pred[1][ind, ..., 1] > threshold
-        delta_y = y_pred[0][ind, ..., 0]
-        delta_x = y_pred[0][ind, ..., 1]
+    for ind in range(np.shape(y_pred)['classification']):
+        contains_dot = y_pred['classification'][ind, ..., 1] > threshold
+        delta_y = y_pred['offset_regression'][ind, ..., 0]
+        delta_x = y_pred['offset_regression'][ind, ..., 1]
 
         dot_pixel_inds = np.argwhere(contains_dot)
         dot_centers.append([[y_ind + delta_y[y_ind, x_ind], x_ind +
@@ -63,32 +62,30 @@ def y_annotations_to_point_list(y_pred, threshold):
     return np.array(dot_centers)
 
 
-def y_annotations_to_point_list_restrictive(y_pred, threshold):
+def y_annotations_to_point_list_restrictive(y_pred, threshold=0.95):
     """Convert raw prediction to a predicted point list: classification of
     pixel as containing dot > threshold AND center regression is contained
-    in the pixel
+    in the pixel. The corresponding regression values will be used to create
+    a final spot position prediction which will be added to the output spot
+    center coordinates list.
 
     Args:
-        y_pred: a batch of predictions, of the format:
-            y_pred[annot_type][ind] is an annotation for image #ind in the
-            batch where annot_type = 0 or 1: 0 - contains_dot,
-            1 - offset matrices
+        y_pred: a dictionary of predictions with keys 'classification' and
+            'offset_regression' corresponding to the named outputs of the
+            dot_net_2D model
         ind: the index of the image in the batch for which to convert the
             annotations
         threshold: a number in [0, 1]. Pixels with classification
-            score > threshold are considered
-        containing a spot center, and their corresponding regression values
-            will be used to create a final spot position prediction which
-            will be added to the output spot center coordinates list.
+            score > threshold are considered containing a spot center 
 
     Returns:
         list: spot center coordinates of the format [[y0, x0], [y1, x1],...]
     """
     dot_centers = []
-    for ind in range(np.shape(y_pred)[1]):
-        contains_dot = y_pred[1][ind, ..., 1] > threshold
-        delta_y = y_pred[0][ind, ..., 0]
-        delta_x = y_pred[0][ind, ..., 1]
+    for ind in range(np.shape(y_pred)['classification']):
+        contains_dot = y_pred['classification'][ind, ..., 1] > threshold
+        delta_y = y_pred['offset_regression'][ind, ..., 0]
+        delta_x = y_pred['offset_regression'][ind, ..., 1]
         contains_its_regression = (abs(delta_x) <= 0.5) & (abs(delta_y) <= 0.5)
 
         final_dot_detection = contains_dot & contains_its_regression
@@ -103,33 +100,28 @@ def y_annotations_to_point_list_restrictive(y_pred, threshold):
 
 def y_annotations_to_point_list_max(y_pred, threshold=0.95, min_distance=2):
     """Convert raw prediction to a predicted point list using PLM to determine
-    local maxima in classification prediction image
+    local maxima in classification prediction image, and their corresponding
+    regression values will be used to create a final spot position prediction
+    which will be added to the output spot center coordinates list.
 
     Args:
-        y_pred: a batch of predictions, of the format: y_pred[annot_type][ind]
-            is an annotation for image #ind in the batch where annot_type = 0
-            or 1: 0 - contains_dot (from classification head),
-            1 - offset matrices (from regression head)
-        ind: the index of the image in the batch for which to convert the
-            annotations
+        y_pred: a dictionary of predictions with keys 'classification' and
+            'offset_regression' corresponding to the named outputs of the
+            dot_net_2D model
         threshold: a number in [0, 1]. Pixels with classification
-            score > threshold are considered
-        containing a spot center,and their corresponding regression values
-            will be used to create a
-        final spot position prediction which will be added to the output spot
-            center coordinates list.
+            score > threshold are considered as containing a spot center
         min_distance: the minimum distance between detected spots in pixels
 
     Returns:
         list: spot center coordinates of the format [[y0, x0], [y1, x1],...]
     """
     dot_centers = []
-    for ind in range(np.shape(y_pred)[1]):
+    for ind in range(np.shape(y_pred)['classification']):
         dot_pixel_inds = peak_local_max(
-            y_pred[1][ind, ..., 1], min_distance=min_distance, threshold_abs=threshold)
+            y_pred['classification'][ind, ..., 1], min_distance=min_distance, threshold_abs=threshold)
 
-        delta_y = y_pred[0][ind, ..., 0]
-        delta_x = y_pred[0][ind, ..., 1]
+        delta_y = y_pred['offset_regression'][ind, ..., 0]
+        delta_x = y_pred['offset_regression'][ind, ..., 1]
 
         dot_centers.append(np.array(
             [[y_ind + delta_y[y_ind, x_ind],
@@ -138,17 +130,17 @@ def y_annotations_to_point_list_max(y_pred, threshold=0.95, min_distance=2):
     return np.array(dot_centers)
 
 
-def y_annotations_to_point_list_cc(y_pred, threshold=0.8):
+def y_annotations_to_point_list_cc(y_pred, threshold=0.95):
     # make final decision to be: average regression over each connected component of above
     # detection threshold pixels
 
     dot_centers = []
-    for ind in range(np.shape(y_pred)[1]):
+    for ind in range(np.shape(y_pred)['classification']):
 
-        delta_y = y_pred[0][ind, ..., 0]
-        delta_x = y_pred[0][ind, ..., 1]
+        delta_y = y_pred['offset_regression'][ind, ..., 0]
+        delta_x = y_pred['offset_regression'][ind, ..., 1]
 
-        blobs = y_pred[1][ind, ..., 1] > threshold
+        blobs = y_pred['classification'][ind, ..., 1] > threshold
         label_image = measure.label(blobs, background=0)
         rp = measure.regionprops(label_image)
 

--- a/deepcell_spots/postprocessing_utils.py
+++ b/deepcell_spots/postprocessing_utils.py
@@ -76,7 +76,7 @@ def y_annotations_to_point_list_restrictive(y_pred, threshold=0.95):
         ind: the index of the image in the batch for which to convert the
             annotations
         threshold: a number in [0, 1]. Pixels with classification
-            score > threshold are considered containing a spot center 
+            score > threshold are considered containing a spot center
 
     Returns:
         list: spot center coordinates of the format [[y0, x0], [y1, x1],...]
@@ -117,8 +117,9 @@ def y_annotations_to_point_list_max(y_pred, threshold=0.95, min_distance=2):
     """
     dot_centers = []
     for ind in range(np.shape(y_pred['classification'])[0]):
-        dot_pixel_inds = peak_local_max(
-            y_pred['classification'][ind, ..., 1], min_distance=min_distance, threshold_abs=threshold)
+        dot_pixel_inds = peak_local_max(y_pred['classification'][ind, ..., 1],
+                                        min_distance=min_distance,
+                                        threshold_abs=threshold)
 
         delta_y = y_pred['offset_regression'][ind, ..., 0]
         delta_x = y_pred['offset_regression'][ind, ..., 1]

--- a/deepcell_spots/postprocessing_utils_test.py
+++ b/deepcell_spots/postprocessing_utils_test.py
@@ -59,7 +59,7 @@ class TestPostProcUtils(test.TestCase):
         y_pred = {key: np.zeros((num_images, image_dim, image_dim, 2)) for key in keys}
         y_pred[keys[1]][:, 1, 1, 1] = np.ones(num_images)
         y_pred[keys[0]] = np.ones(
-            (1, num_images, image_dim, image_dim, 2))
+            (num_images, image_dim, image_dim, 2))
         threshold = 0.9
         coords = y_annotations_to_point_list(y_pred, threshold)
 
@@ -91,7 +91,7 @@ class TestPostProcUtils(test.TestCase):
         y_pred = {key: np.zeros((num_images, image_dim, image_dim, 2)) for key in keys}
         y_pred[keys[1]][:, 1, 1, 1] = np.ones(num_images)
         y_pred[keys[0]] = np.ones(
-            (1, num_images, image_dim, image_dim, 2))
+            (num_images, image_dim, image_dim, 2))
         threshold = 0.9
 
         coords = y_annotations_to_point_list_restrictive(y_pred, threshold)
@@ -106,7 +106,7 @@ class TestPostProcUtils(test.TestCase):
         y_pred = {key: np.zeros((num_images, image_dim, image_dim, 2)) for key in keys}
         y_pred[keys[1]][:, 1, 1, 1] = np.ones(num_images)
         y_pred[keys[0]] = np.ones(
-            (1, num_images, image_dim, image_dim, 2)) * 0.4
+            (num_images, image_dim, image_dim, 2)) * 0.4
         threshold = 0.9
         coords = y_annotations_to_point_list(y_pred, threshold)
 
@@ -140,7 +140,7 @@ class TestPostProcUtils(test.TestCase):
         y_pred = {key: np.zeros((num_images, image_dim, image_dim, 2)) for key in keys}
         y_pred[keys[1]][:, 1, 1, 1] = np.ones(num_images)
         y_pred[keys[0]] = np.ones(
-            (1, num_images, image_dim, image_dim, 2))
+            (num_images, image_dim, image_dim, 2))
         threshold = 0.9
         coords = y_annotations_to_point_list_max(y_pred, threshold)
 
@@ -173,7 +173,7 @@ class TestPostProcUtils(test.TestCase):
         y_pred = {key: np.zeros((num_images, image_dim, image_dim, 2)) for key in keys}
         y_pred[keys[1]][:, 1, 1, 1] = np.ones(num_images)
         y_pred[keys[0]] = np.ones(
-            (1, num_images, image_dim, image_dim, 2))
+            (num_images, image_dim, image_dim, 2))
         threshold = 0.9
         coords = y_annotations_to_point_list_cc(y_pred, threshold)
 

--- a/deepcell_spots/postprocessing_utils_test.py
+++ b/deepcell_spots/postprocessing_utils_test.py
@@ -39,8 +39,9 @@ class TestPostProcUtils(test.TestCase):
         # Easy example with one spot
         num_images = 1
         image_dim = 10
-        y_pred = np.zeros((2, num_images, image_dim, image_dim, 2))
-        y_pred[1, 0, 1, 1, 1] = 1
+        keys = ['offset_regression', 'classification']
+        y_pred = {key: np.zeros((num_images, image_dim, image_dim, 2)) for key in keys}
+        y_pred[keys[1]][0, 1, 1, 1] = 1
         threshold = 0.9
 
         coords = y_annotations_to_point_list(y_pred, threshold)
@@ -54,9 +55,10 @@ class TestPostProcUtils(test.TestCase):
         # adds to coords
         num_images = 10
         image_dim = 10
-        y_pred = np.zeros((2, num_images, image_dim, image_dim, 2))
-        y_pred[1, :, 1, 1, 1] = np.ones(num_images)
-        y_pred[0, :, :, :, :] = np.ones(
+        keys = ['offset_regression', 'classification']
+        y_pred = {key: np.zeros((num_images, image_dim, image_dim, 2)) for key in keys}
+        y_pred[keys[1]][:, 1, 1, 1] = np.ones(num_images)
+        y_pred[keys[0]] = np.ones(
             (1, num_images, image_dim, image_dim, 2))
         threshold = 0.9
         coords = y_annotations_to_point_list(y_pred, threshold)
@@ -70,8 +72,9 @@ class TestPostProcUtils(test.TestCase):
         # Easy example with one spot
         num_images = 1
         image_dim = 10
-        y_pred = np.zeros((2, num_images, image_dim, image_dim, 2))
-        y_pred[1, 0, 1, 1, 1] = 1
+        keys = ['offset_regression', 'classification']
+        y_pred = {key: np.zeros((num_images, image_dim, image_dim, 2)) for key in keys}
+        y_pred[keys[1]][0, 1, 1, 1] = 1
         threshold = 0.9
 
         coords = y_annotations_to_point_list_restrictive(y_pred, threshold)
@@ -84,9 +87,10 @@ class TestPostProcUtils(test.TestCase):
         # Regression output needs to be below some threshold value (0.5)
         num_images = 1
         image_dim = 10
-        y_pred = np.zeros((2, num_images, image_dim, image_dim, 2))
-        y_pred[1, 0, 1, 1, 1] = 1
-        y_pred[0, :, :, :, :] = np.ones(
+        keys = ['offset_regression', 'classification']
+        y_pred = {key: np.zeros((num_images, image_dim, image_dim, 2)) for key in keys}
+        y_pred[keys[1]][:, 1, 1, 1] = np.ones(num_images)
+        y_pred[keys[0]] = np.ones(
             (1, num_images, image_dim, image_dim, 2))
         threshold = 0.9
 
@@ -98,9 +102,10 @@ class TestPostProcUtils(test.TestCase):
         # Regression output needs to be below some threshold value (0.5), regression adds to coords
         num_images = 10
         image_dim = 10
-        y_pred = np.zeros((2, num_images, image_dim, image_dim, 2))
-        y_pred[1, :, 1, 1, 1] = np.ones(num_images)
-        y_pred[0, :, :, :, :] = np.ones(
+        keys = ['offset_regression', 'classification']
+        y_pred = {key: np.zeros((num_images, image_dim, image_dim, 2)) for key in keys}
+        y_pred[keys[1]][:, 1, 1, 1] = np.ones(num_images)
+        y_pred[keys[0]] = np.ones(
             (1, num_images, image_dim, image_dim, 2)) * 0.4
         threshold = 0.9
         coords = y_annotations_to_point_list(y_pred, threshold)
@@ -115,8 +120,9 @@ class TestPostProcUtils(test.TestCase):
         # Easy example with one spot
         num_images = 1
         image_dim = 10
-        y_pred = np.zeros((2, num_images, image_dim, image_dim, 2))
-        y_pred[1, 0, 1, 1, 1] = 1
+        keys = ['offset_regression', 'classification']
+        y_pred = {key: np.zeros((num_images, image_dim, image_dim, 2)) for key in keys}
+        y_pred[keys[1]][0, 1, 1, 1] = 1
         threshold = 0.9
 
         coords = y_annotations_to_point_list_max(y_pred, threshold)
@@ -130,9 +136,10 @@ class TestPostProcUtils(test.TestCase):
         # regression adds to coords
         num_images = 10
         image_dim = 10
-        y_pred = np.zeros((2, num_images, image_dim, image_dim, 2))
-        y_pred[1, :, 1, 1, 1] = np.ones(num_images)
-        y_pred[0, :, :, :, :] = np.ones(
+        keys = ['offset_regression', 'classification']
+        y_pred = {key: np.zeros((num_images, image_dim, image_dim, 2)) for key in keys}
+        y_pred[keys[1]][:, 1, 1, 1] = np.ones(num_images)
+        y_pred[keys[0]] = np.ones(
             (1, num_images, image_dim, image_dim, 2))
         threshold = 0.9
         coords = y_annotations_to_point_list_max(y_pred, threshold)
@@ -146,8 +153,9 @@ class TestPostProcUtils(test.TestCase):
         # Easy example with one spot
         num_images = 1
         image_dim = 10
-        y_pred = np.zeros((2, num_images, image_dim, image_dim, 2))
-        y_pred[1, 0, 1, 1, 1] = 1
+        keys = ['offset_regression', 'classification']
+        y_pred = {key: np.zeros((num_images, image_dim, image_dim, 2)) for key in keys}
+        y_pred[keys[1]][0, 1, 1, 1] = 1
         threshold = 0.9
 
         coords = y_annotations_to_point_list_cc(y_pred, threshold)
@@ -161,9 +169,10 @@ class TestPostProcUtils(test.TestCase):
         # regression adds to coords
         num_images = 10
         image_dim = 10
-        y_pred = np.zeros((2, num_images, image_dim, image_dim, 2))
-        y_pred[1, :, 1, 1, 1] = np.ones(num_images)
-        y_pred[0, :, :, :, :] = np.ones(
+        keys = ['offset_regression', 'classification']
+        y_pred = {key: np.zeros((num_images, image_dim, image_dim, 2)) for key in keys}
+        y_pred[keys[1]][:, 1, 1, 1] = np.ones(num_images)
+        y_pred[keys[0]] = np.ones(
             (1, num_images, image_dim, image_dim, 2))
         threshold = 0.9
         coords = y_annotations_to_point_list_cc(y_pred, threshold)


### PR DESCRIPTION
This PR makes the changes necessary to name the outputs of the `dot_net_2D` model after prediction in a dictionary as opposed to a list. I have also removed arguments for scaling from the application, which is not currently supported by the spots model.