### PR TITLE
Add unit tests for model and loss scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # DeepCell Spots
 
 [![Build Status](https://github.com/vanvalenlab/deepcell-spots/workflows/build/badge.svg)](https://github.com/vanvalenlab/deepcell-spots/actions)
+[![Documentation Status](https://readthedocs.org/projects/deepcell-spots/badge/?version=latest)](https://deepcell-spots.readthedocs.io/en/latest/?badge=latest)
 [![Coverage Status](https://coveralls.io/repos/github/vanvalenlab/deepcell-spots/badge.svg)](https://coveralls.io/github/vanvalenlab/deepcell-spots)
 [![Modified Apache 2.0](https://img.shields.io/badge/license-Modified%20Apache%202-blue)](https://github.com/vanvalenlab/deepcell-spots/blob/master/LICENSE)
 [![PyPI version](https://badge.fury.io/py/DeepCell-Spots.svg)](https://badge.fury.io/py/DeepCell-Spots)

--- a/deepcell_spots/dotnet_losses.py
+++ b/deepcell_spots/dotnet_losses.py
@@ -35,7 +35,7 @@ from deepcell import losses
 from tensorflow.keras import backend as K
 
 
-def smooth_l1(y_true, y_pred, sigma=3.0):  # , axis=None):
+def smooth_l1(y_true, y_pred, sigma=3.0):
     """Compute the smooth L1 loss of `y_pred` w.r.t. `y_true`.
 
     Similar to ``deepcell.losses.smooth_l1`` without summation over

--- a/deepcell_spots/dotnet_losses_test.py
+++ b/deepcell_spots/dotnet_losses_test.py
@@ -1,0 +1,64 @@
+# Copyright 2019-2022 The Van Valen Lab at the California Institute of
+# Technology (Caltech), with support from the Paul Allen Family Foundation,
+# Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
+# All rights reserved.
+#
+# Licensed under a modified Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.github.com/vanvalenlab/deepcell-spots/LICENSE
+#
+# The Work provided may be used for non-commercial academic purposes only.
+# For any other use of the Work, including commercial use, please contact:
+# vanvalenlab@gmail.com
+#
+# Neither the name of Caltech nor the names of its contributors may be used
+# to endorse or promote products derived from this software without specific
+# prior written permission.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Tests for loss functions for DeepCell spots"""
+
+import numpy as np
+
+import tensorflow as tf
+from tensorflow import keras
+from tensorflow.python.platform import test
+
+from deepcell_spots import dotnet_losses
+
+
+losses = dotnet_losses.DotNetLosses()
+
+DOTNET_LOSSES = [
+    losses.regression_loss,
+    losses.classification_loss,
+    losses.classification_loss_regularized
+]
+
+
+class KerasLossesTest(test.TestCase):
+
+    def test_objective_shapes_4d(self):
+        with self.cached_session():
+            y_a = keras.backend.variable(np.random.random((5, 6, 7, 8)))
+            y_b = keras.backend.variable(np.random.random((5, 6, 7, 8)))
+
+            # differs from deepcell.losses.smooth_l1 bc no summation over channels
+            objective_output = dotnet_losses.smooth_l1(y_a, y_b)
+            self.assertListEqual(objective_output.shape.as_list(), [5, 6, 7, 8])
+
+            for obj in DOTNET_LOSSES:
+                objective_output = obj(y_a, y_b)
+                self.assertListEqual(objective_output.shape.as_list(), [])
+
+
+if __name__ == '__main__':
+    test.main()

--- a/deepcell_spots/dotnet_test.py
+++ b/deepcell_spots/dotnet_test.py
@@ -66,7 +66,7 @@ class FeatureNetTest(keras_parameterized.TestCase):
         },
     ])
     def test_dot_net_2D(self, padding_mode, norm_method, shape,
-                               receptive_field, data_format):
+                        receptive_field, data_format):
 
         inputs = None
         n_skips = 3
@@ -79,8 +79,7 @@ class FeatureNetTest(keras_parameterized.TestCase):
                 inputs=inputs,
                 n_skips=n_skips,
                 norm_method=norm_method,
-                padding_mode=padding_mode
-                )
+                padding_mode=padding_mode)
             self.assertEqual(len(model.output_shape), 2)
             self.assertEqual(len(model.output_shape[0]), 4)
             self.assertEqual(len(model.output_shape[1]), 4)

--- a/deepcell_spots/dotnet_test.py
+++ b/deepcell_spots/dotnet_test.py
@@ -1,0 +1,86 @@
+# Copyright 2019-2022 The Van Valen Lab at the California Institute of
+# Technology (Caltech), with support from the Paul Allen Family Foundation,
+# Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
+# All rights reserved.
+#
+# Licensed under a modified Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.github.com/vanvalenlab/deepcell-spots/LICENSE
+#
+# The Work provided may be used for non-commercial academic purposes only.
+# For any other use of the Work, including commercial use, please contact:
+# vanvalenlab@gmail.com
+#
+# Neither the name of Caltech nor the names of its contributors may be used
+# to endorse or promote products derived from this software without specific
+# prior written permission.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Tests for CNN dotnet architechture"""
+
+from absl.testing import parameterized
+
+from tensorflow.python.framework import test_util as tf_test_util
+from keras import keras_parameterized
+
+from tensorflow.keras import backend as K
+
+from deepcell_spots.dotnet import dot_net_2D
+
+
+class FeatureNetTest(keras_parameterized.TestCase):
+
+    @keras_parameterized.run_all_keras_modes
+    @parameterized.named_parameters([
+        {
+            'testcase_name': 'reflect_padding',
+            'padding_mode': 'reflect',
+            'norm_method': 'std',
+            'shape': (128, 128, 1),
+            'receptive_field': 13,
+            'data_format': 'channels_last'
+        },
+        {
+            'testcase_name': 'zero_padding',
+            'padding_mode': 'zero',
+            'norm_method': 'std',
+            'shape': (128, 128, 1),
+            'receptive_field': 13,
+            'data_format': 'channels_last'
+        },
+        {
+            'testcase_name': 'no_norm',
+            'padding_mode': 'reflect',
+            'norm_method': None,
+            'shape': (128, 128, 1),
+            'receptive_field': 13,
+            'data_format': 'channels_last'
+        },
+    ])
+    def test_dot_net_2D(self, padding_mode, norm_method, shape,
+                               receptive_field, data_format):
+
+        inputs = None
+        n_skips = 3
+
+        with self.cached_session():
+            K.set_image_data_format(data_format)
+            model = dot_net_2D(
+                receptive_field=receptive_field,
+                input_shape=shape,
+                inputs=inputs,
+                n_skips=n_skips,
+                norm_method=norm_method,
+                padding_mode=padding_mode
+                )
+            self.assertEqual(len(model.output_shape), 2)
+            self.assertEqual(len(model.output_shape[0]), 4)
+            self.assertEqual(len(model.output_shape[1]), 4)

--- a/deepcell_spots/utils.py
+++ b/deepcell_spots/utils.py
@@ -141,8 +141,8 @@ def generate_transformation_matrix(transform_parameters, image_shape, img_row_ax
                 - `'zy'`: Float. Zoom in the y direction.
                 - `'flip_horizontal'`: Boolean. Horizontal flip. - NOT USED HERE
                 - `'flip_vertical'`: Boolean. Vertical flip. - NOT USED HERE
-                - `'channel_shift_intensity'`: Float. Channel shift intensity.
-                - `'brightness'`: Float. Brightness shift intensity.
+                - `'channel_shift_intensity'`: Float. Channel shift intensity. - NOT USED HERE
+                - `'brightness'`: Float. Brightness shift intensity. - NOT USED HERE
 
     Returns:
         (array, array): final_affine_matrix (2*2 matrix ,denote below: T),

--- a/deepcell_spots/utils_test.py
+++ b/deepcell_spots/utils_test.py
@@ -117,7 +117,7 @@ class TestUtils(test.TestCase):
 
     def test_affine_transform_points(self):
         num_points = 10
-        points = np.random.randint(low=0, high=10, size=(num_points, 2))
+        points = np.random.randint(low=1, high=9, size=(num_points, 2))
 
         transform_parameters = {
             'theta': 0,
@@ -130,9 +130,20 @@ class TestUtils(test.TestCase):
 
         image_shape = (10, 10)
 
+        # Fill with nearest
         transformed_points_in_image = affine_transform_points(points,
                                                               transform_parameters,
-                                                              image_shape)
+                                                              image_shape,
+                                                              fill_mode='nearest')
+
+        self.assertEqual(np.shape(transformed_points_in_image), (num_points, 2))
+        self.assertAllEqual(points, transformed_points_in_image)
+
+        # Fill with reflect
+        transformed_points_in_image = affine_transform_points(points,
+                                                              transform_parameters,
+                                                              image_shape,
+                                                              fill_mode='reflect')
 
         self.assertEqual(np.shape(transformed_points_in_image), (num_points, 2))
         self.assertAllEqual(points, transformed_points_in_image)

--- a/deepcell_spots/utils_test.py
+++ b/deepcell_spots/utils_test.py
@@ -148,6 +148,15 @@ class TestUtils(test.TestCase):
         self.assertEqual(np.shape(transformed_points_in_image), (num_points, 2))
         self.assertAllEqual(points, transformed_points_in_image)
 
+        # Fill with wrap
+        transformed_points_in_image = affine_transform_points(points,
+                                                              transform_parameters,
+                                                              image_shape,
+                                                              fill_mode='wrap')
+
+        self.assertEqual(np.shape(transformed_points_in_image), (num_points, 2))
+        self.assertAllEqual(points, transformed_points_in_image)
+
 
 if __name__ == '__main__':
     test.main()

--- a/deepcell_spots/utils_test.py
+++ b/deepcell_spots/utils_test.py
@@ -24,12 +24,14 @@
 # limitations under the License.
 # ==============================================================================
 
-"""Functions for utils"""
+"""Tests for utils"""
 
 import numpy as np
 from tensorflow.python.platform import test
 
-from deepcell_spots.utils import subpixel_distance_transform
+from deepcell_spots.utils import (affine_transform_points,
+                                  generate_transformation_matrix,
+                                  subpixel_distance_transform)
 
 
 class TestUtils(test.TestCase):
@@ -54,10 +56,58 @@ class TestUtils(test.TestCase):
         self.assertEqual(np.shape(delta_x), image_shape)
         self.assertEqual(np.shape(nearest_point), image_shape)
 
-        # are more tests needed?
+    def test_generate_transformation_matrix(self):
+        transform_parameters = {
+            'theta': 0,
+            'tx': 0,
+            'ty': 0,
+            'shear': 0,
+            'zx': 1,
+            'zy': 1
+        }
 
-    # def test_generate_transformation_matrix(self):
-    #     # not sure what to test beside the shape
+        image_shape = (10, 10)
+        img_row_axis = 0
+        img_col_axis = 1
+
+        final_affine_matrix, final_offset = generate_transformation_matrix(
+            transform_parameters,
+            image_shape,
+            img_row_axis,
+            img_col_axis
+        )
+
+        # null transformation matrix
+        transform_matrix = np.array([[1, 0, 0],
+                                     [0, 1, 0],
+                                     [0, 0, 1]])
+
+        self.assertEqual(np.shape(final_affine_matrix), (2, 2))
+        self.assertEqual(len(final_offset), 2)
+        self.assertAllEqual(final_affine_matrix, transform_matrix[:2, :2])
+        self.assertAllEqual(final_offset, transform_matrix[:2, 2])
+
+    def test_affine_transform_points(self):
+        num_points = 10
+        points = np.random.randint(low=0, high=10, size=(num_points, 2))
+
+        transform_parameters = {
+            'theta': 0,
+            'tx': 0,
+            'ty': 0,
+            'shear': 0,
+            'zx': 1,
+            'zy': 1
+        }
+
+        image_shape = (10, 10)
+
+        transformed_points_in_image = affine_transform_points(points,
+                                                              transform_parameters,
+                                                              image_shape)
+
+        self.assertEqual(np.shape(transformed_points_in_image), (num_points, 2))
+        self.assertAllEqual(points, transformed_points_in_image)
 
 
 if __name__ == '__main__':

--- a/deepcell_spots/utils_test.py
+++ b/deepcell_spots/utils_test.py
@@ -87,6 +87,34 @@ class TestUtils(test.TestCase):
         self.assertAllEqual(final_affine_matrix, transform_matrix[:2, :2])
         self.assertAllEqual(final_offset, transform_matrix[:2, 2])
 
+        transform_parameters = {
+            'theta': 5,
+            'tx': 1,
+            'ty': 1,
+            'shear': 5,
+            'zx': 5,
+            'zy': 5
+        }
+
+        image_shape = (10, 10)
+        img_row_axis = 0
+        img_col_axis = 1
+
+        final_affine_matrix, final_offset = generate_transformation_matrix(
+            transform_parameters,
+            image_shape,
+            img_row_axis,
+            img_col_axis
+        )
+
+        # null transformation matrix
+        transform_matrix = np.array([[1, 0, 0],
+                                     [0, 1, 0],
+                                     [0, 0, 1]])
+
+        self.assertEqual(np.shape(final_affine_matrix), (2, 2))
+        self.assertEqual(len(final_offset), 2)
+
     def test_affine_transform_points(self):
         num_points = 10
         points = np.random.randint(low=0, high=10, size=(num_points, 2))


### PR DESCRIPTION
This PR adds unit tests for `dotnet.py`, `dotnet_losses.py`, and `utils.py`.  It also adds the "docs" badge to the README.