### PR TITLE
Update pinned deepcell version to 0.12.4 in Dockerfile 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Use vanvalenlab/deepcell-tf as the base image
 # Change the build arg to edit the deepcell version.
 # Only supporting python3.
-ARG DEEPCELL_VERSION=0.12.0-gpu
+ARG DEEPCELL_VERSION=0.12.4-gpu
 
 FROM vanvalenlab/deepcell-tf:${DEEPCELL_VERSION}
 


### PR DESCRIPTION
This PR updates the pinned deepcell version in the Dockerfile. This version determines the base image used to build the deepcell-spots image.