### PR TITLE
Tighten CI configuration

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,6 +9,10 @@ on:
   pull_request:
     branches: [master]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   tests:
 


### PR DESCRIPTION
A couple minor tweaks to the CI configuration to (hopefully) prevent duplication and unnecessary runs on experimental branches. Specifically:
 - 0ce6c0c limits CI so that runs are only triggered when either 1) a PR to `master` is opened, or 2) there is a new push to a branch from which a PR already originates. This should prevent CI from running when commits are pushed up to non-master branches.
 - 48f4bc7 adds a check which will cancel any in-progress jobs when new changes are pushed up. This can help e.g. when you push two commits up in rapid succession. By default, GH will queue up the 2nd set of jobs and wait for the first set to finish. With this option, the first set of jobs will be cancelled and the 2nd job will start immediately.

The motivation for these changes is to reduce the CI load in private repositories.