### PR TITLE
Remove one data validation check from Polaris

### DIFF
--- a/deepcell_spots/applications/polaris.py
+++ b/deepcell_spots/applications/polaris.py
@@ -244,11 +244,6 @@ class Polaris:
                                  'has shape {} and segmentation_image has shape {}'
                                  ''.format(spots_image.shape, segmentation_image.shape))
 
-            if segmentation_image.shape[-1] != 1:
-                raise ValueError('Shape of channel dimension of segmentation_image should equal '
-                                 'to zero, but input segmentation_image had shape {} (b,x,y,c).'
-                                 ''.format(segmentation_image.shape))
-
         if background_image is not None:
             if spots_image.shape[:-1] != background_image.shape[:-1]:
                 raise ValueError('Batch, x, and y dimensions of spots_image '


### PR DESCRIPTION
This PR removes a data validation check that contains an error from Polaris. The check enforces that the segmentation image has one channel when Mesmer predictions usually have two.