### PR TITLE
Fix bug for multi-batch predictions with pixel-wise decoding

### DIFF
--- a/deepcell_spots/applications/polaris.py
+++ b/deepcell_spots/applications/polaris.py
@@ -456,6 +456,7 @@ class Polaris:
                                 decoding_result)
         df_intensities = pd.DataFrame(spots_intensities_vec)
         df_results = pd.concat([df_spots, df_intensities], axis=1)
+        df_results = df_results.reset_index(drop=True)
 
         if self.image_type == 'multiplex':
             dec_prob_im = np.zeros((spots_image.shape[:3]))


### PR DESCRIPTION
This PR addresses a bug that affected multi-batch predictions for Polaris' new pixel-wise decoding method. Now, Polaris iterates through the batch index to find the local maxima in the masked spot probability image.