### PR TITLE
Move masking function outside of Polaris application

### DIFF
--- a/deepcell_spots/applications/polaris.py
+++ b/deepcell_spots/applications/polaris.py
@@ -358,7 +358,7 @@ class Polaris:
             df_intensities (pandas.DataFrame): Columns are channels and rows are spots.
             segmentation_result (numpy.array): Segmentation mask with shape `[batch, x, y, 1]`.
         """
-        self._validate_prediction_input(spots_image, segmentation_image, threshold)
+        self._validate_prediction_input(spots_image, segmentation_image, mask, threshold)
         if self.image_type == 'multiplex':
             skip_round = np.array(np.sum(self.df_barcodes.iloc[:,1:], axis=0)==0)
         else:

--- a/deepcell_spots/applications/polaris_test.py
+++ b/deepcell_spots/applications/polaris_test.py
@@ -117,10 +117,6 @@ class TestPolaris(test.TestCase):
                 _ = app.predict(spots_image=spots_image, threshold=1.1)
             with self.assertRaises(ValueError):
                 _ = app.predict(spots_image=spots_image, threshold=-1.1)
-            with self.assertRaises(ValueError):
-                _ = app.predict(spots_image=spots_image, mask_threshold=1.1)
-            with self.assertRaises(ValueError):
-                _ = app.predict(spots_image=spots_image, mask_threshold=-1.1)
 
             # test segmentation app error
             app = Polaris(spots_model=spots_model, segmentation_type='no segmentation')


### PR DESCRIPTION
This PR moves the abstracted `_mask_spots` to be outside of the application. The function is now available in `results_utils.py`. The unit tests and example notebook for Polaris have been updated.