### PR TITLE
Update spot detection model to SpotDetection-8

### DIFF
--- a/deepcell_spots/applications/spot_detection.py
+++ b/deepcell_spots/applications/spot_detection.py
@@ -104,8 +104,8 @@ class SpotDetection(Application):
         'lr': 0.01,
         'lr_decay': 0.99,
         'training_seed': 0,
-        'n_epochs': 10,
-        'training_steps_per_epoch': 552
+        'n_epochs': 50,
+        'training_steps_per_epoch': 849
     }
 
     def __init__(self, model=None):

--- a/deepcell_spots/applications/spot_detection.py
+++ b/deepcell_spots/applications/spot_detection.py
@@ -41,9 +41,9 @@ from deepcell_spots.utils.postprocessing_utils import y_annotations_to_point_lis
 from deepcell_spots.utils.preprocessing_utils import min_max_normalize
 
 
-MODEL_KEY = 'models/SpotDetection-7.tar.gz'
+MODEL_KEY = 'models/SpotDetection-8.tar.gz'
 MODEL_NAME = 'SpotDetection'
-MODEL_HASH = 'f52d473ad7e4ce33472f1a9a9cae2d85'
+MODEL_HASH = 'a6164e48ef8872a9524b4ec6726859d7'
 
 
 def output_to_dictionary(output_images, output_names):


### PR DESCRIPTION
This PR updates the default model for the `SpotDetection` application to `SpotDetection-8`. The model hash and model metadata have also been updated accordingly. The training data used to train `SpotDetection-8`(SpotNet v1.1)  adds Airlocalize to the set of spot detection methods used to create the consensus spot labels. 